### PR TITLE
Added `theme-color` meta extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
 		<meta name="description" content="" />
 		<meta name="keywords" content="" />
 		<meta name="copyright" content="" />
+
+		<meta name="theme-color" content="#ddd" />
 		
 		<link rel="author" href="" />
 		<link rel="canonical" href="" />


### PR DESCRIPTION
# Description

The `theme-color` meta extension defines a suggested color that browsers should use if they customize the display of individual pages in their UIs with varying colors.

The `theme-color` meta extension is currently supported by Chrome 39+ for Android Lollipop (5.0+) and Firefox OS 2.1+.
# Samples

The following sample uses this `theme-color` configuration:

``` html
<meta name="theme-color" content="#263238" />
```

When rendered on Chrome 40 for Android Lollipop the theme color for the following page is replaced with the color set on `theme-color`.

The theme color is displayed as seen in Android's multitasking window:

![screenshot_2015-02-28-16-49-52](https://cloud.githubusercontent.com/assets/5663877/6425731/f7819fc2-bf6a-11e4-9951-840bc4f2df18.png)

The `theme-color` meta also updates the header colors within the Chrome app itself.

![screenshot_2015-02-28-16-50-01](https://cloud.githubusercontent.com/assets/5663877/6425732/ff4d2b2c-bf6a-11e4-91ff-825ced7511c5.png)
# References
- https://github.com/whatwg/meta-theme-color
- https://github.com/h5bp/html5-boilerplate/blob/master/dist/doc/extend.md#theme-color
