### PR TITLE
Added application icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 		<meta property="og:image" content="" />
 
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
+		<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-precomposed.png">
 		<meta name="msapplication-TileColor" content="#ddd">
 		<meta name="msapplication-TileImage" content="/mstile-144x144.png" />
 

--- a/index.html
+++ b/index.html
@@ -5,29 +5,33 @@
 		<meta charset="utf-8" />
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		
+
 		<title></title>
-		
+
 		<meta name="description" content="" />
 		<meta name="keywords" content="" />
 		<meta name="author" content="" />
 		<meta name="theme-color" content="#ddd" />
-		
+
 		<base href="">
-		
+
 		<meta property="og:type" content="website" />
 		<meta property="og:site_name" content="" />
 		<meta property="og:title" content="" />
 		<meta property="og:description" content="" />
 		<meta property="og:image" content="" />
-		
+
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
-		
+		<meta name="msapplication-TileColor" content="#ddd">
+		<meta name="msapplication-TileImage" content="/mstile-144x144.png" />
+
+		<meta name="application-name" content="">
+
 		<link rel="stylesheet" type="text/css" media="screen" href="css/bootstrap.min.css" />
 		<link rel="stylesheet" type="text/css" media="screen" href="css/font-awesome.min.css" />
 		<link rel="stylesheet" type="text/css" media="screen" href="http://fonts.googleapis.com/css?family=" />
 		<link rel="stylesheet" type="text/css" media="screen" href="css/style.css" />
-		
+
 		<!--[if lt IE 9]>
 			<script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 			<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
@@ -36,7 +40,7 @@
 
 	<body>
 		<!-- Your content goes here -->
-		
+
 		<!-- Scripts go below this line -->
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 		<script src="js/bootstrap.min.js"></script>


### PR DESCRIPTION
Adds tile colors for pinned sites on Windows 8+ Start menu (`msapplication-TileImage` and `msapplication-TileColor`), and also icons for Apple home screens (`apple-touch-icon-precomposed`)

**References:**
- [`apple-touch-icon-precomposed`](https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html)
- [`msapplication-*`](https://msdn.microsoft.com/en-us/library/bg183312%28v=vs.85%29.aspx)
